### PR TITLE
run linters on macOS and Windows as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Mostly to catch if we correctly specified build-tags (see https://github.com/containerd/fifo/pull/36)
